### PR TITLE
Update RachevRatio.R for proper argument passing from higher level function

### DIFF
--- a/R/RachevRatio.R
+++ b/R/RachevRatio.R
@@ -92,7 +92,7 @@ RachevRatio <- function(R, alpha=0.1, beta=0.1, rf=0,
   }
   
   # Computation of Rachev Ratio
-  myRachevRatio = t(apply(R, 2, RachevRatioFN, alpha=0.1, beta=0.1, rf=0))
+  myRachevRatio = t(apply(R, 2, RachevRatioFN, alpha=alpha, beta=beta, rf=rf))
   rownames(myRachevRatio) = "RachevRatio"
   
   if(SE) # Check if SE computation


### PR DESCRIPTION
The arguments passed to myRachevRatio() should be the values passed into the original function call. The current implementation has a bug in which the default values are passed into this function regardless of what values are passed to the higher level RachevRatio() function.